### PR TITLE
Change presentation keys for better experience

### DIFF
--- a/coffee/classes/mds_main_menu.coffee
+++ b/coffee/classes/mds_main_menu.coffee
@@ -186,7 +186,6 @@ module.exports = class MdsMainMenu
             }
             {
               label: '&Start Presentation'
-              accelerator: 'Space'
               click: =>
                 @window.mdsWindow.send 'startPresentation'
             }

--- a/coffee/classes/mds_main_menu.coffee
+++ b/coffee/classes/mds_main_menu.coffee
@@ -175,13 +175,13 @@ module.exports = class MdsMainMenu
             {
               label: 'Pre&vious Slide'
               enabled: @window?
-              accelerator: 'CmdOrCtrl+Up'
+              accelerator: 'PageUp'
               click: (i, w) => @window.mdsWindow.send 'jumpSlide', false unless @window.mdsWindow.freeze
             }
             {
               label: '&Next Slide'
               enabled: @window?
-              accelerator: 'CmdOrCtrl+Down'
+              accelerator: 'PageDown'
               click: (i, w) => @window.mdsWindow.send 'jumpSlide', true unless @window.mdsWindow.freeze
             }
             {


### PR DESCRIPTION
> This PR changes some keys for presentation. 🎉

1. Changed to `PageUp` and `PageDown` keys for moving between slides, allowing you to use some presenter devices while using the presentation mode (which is awesome btw). Those presenters usually have "page up" and "page down" keys.

2. Removed the `Space` key for starting the presentation, because if you were typing something and just add a space the presentation mode starts. Now to start the presentation mode must go on `View -> Start Presentation` menu item.

Thanks!