### PR TITLE
Typo (done) was missing

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -125,7 +125,7 @@ gulp.task 'dist', ['clean:dist'], ->
 gulp.task 'package', ['clean:packages', 'dist'], (done) ->
   runSequence 'package:win32', 'package:darwin', 'package:linux', done
 
-gulp.task 'package:win32', ->
+gulp.task 'package:win32', (done) ->
   packageElectron {
     platform: 'win32'
     arch: 'ia32,x64'


### PR DESCRIPTION
See this error message:
```
[09:54:33] 'package' errored after 2.85 ms
[09:54:33] ReferenceError in plugin "run-sequence(build)"
Message:
    done is not defined
Stack:
ReferenceError: done is not defined
    at Gulp.<anonymous> (marp/gulpfile.coffee:159:8)
```