### PR TITLE
Fix page number following

### DIFF
--- a/coffee/classes/mds_md_setting.coffee
+++ b/coffee/classes/mds_md_setting.coffee
@@ -116,7 +116,7 @@ module.exports = class MdsMdSetting
   constructor: () ->
     @_settings = []
 
-  set: (fromPage, prop, value, following = false) =>
+  set: (fromPage, prop, value, following = true) =>
     return false unless MdsMdSetting.isValidProp(fromPage, prop)
 
     if duckType = MdsMdSetting.findDuckTypes(prop)
@@ -133,14 +133,14 @@ module.exports = class MdsMdSetting
 
       continue if !transformedValue?
 
-      if (idx = @_findSettingIdx fromPage, targetProp, !following)?
+      if (idx = @_findSettingIdx fromPage, targetProp, following)?
         @_settings[idx].value = transformedValue
       else
         @_settings.push
           page:        fromPage
           property:    targetProp
           value:       transformedValue
-          noFollowing: !following
+          noFollowing: following
 
   setGlobal: (prop, value) => @set 0, prop, value, false
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "run-sequence": "^2.2.1"
   },
   "dependencies": {
+    "chokidar": "^2.1.2",
     "codemirror": "^5",
     "extend": "^3",
     "github-markdown-css": "^2",


### PR DESCRIPTION
 ## Fix page-number following on all next pages
Actually, the following of page numbers to all next pages is _inversed_.
```*page-number: true``` is need for page numbers to follow on all pages instead of ```page-number: true``` mentioned in the doc.
This behaviour was introduce by a boolean tipo when switching from ```!!noFollowing``` to ```!following``` in https://github.com/fedorio/marp/commit/5df478e#diff-c649a5e6df73335c04bb6ac5ab15659eL111